### PR TITLE
Add bios support from "run core"

### DIFF
--- a/PPSSPP/libretro-PPSSPP-launcher.c
+++ b/PPSSPP/libretro-PPSSPP-launcher.c
@@ -147,10 +147,9 @@ void retro_run(void)
 /*
    Linux/macOS: Check if file is ELF, then use it.
 */
-
 #if defined __linux__ || __APPLE__
 
- int is_elf_executable(const char *filename) {
+static int is_elf_executable(const char *filename) {
     
     unsigned char magic[4];
     int fd = open(filename, O_RDONLY);
@@ -165,13 +164,12 @@ void retro_run(void)
     return (read_bytes == 4 && memcmp(magic, ELF_MAGIC, 4) == 0);
 }
 #endif
-
 /**
  * libretro callback; Called when a game is to be loaded.
  *
  *  - Linux/macOS:
  *        - resolve HOME path 
- *        - create dir for emulator files 
+ *        - create dir for emulator files and bios
  *        - apply regex search with glob, filter by file and ELF executable
  *  
  *  - Windows:
@@ -181,7 +179,8 @@ void retro_run(void)
  *    
  * - Final Steps:
  *       - attach ROM absolute path from info->path in double quotes for system() function, avoids truncation.
- *        - if info->path has no ROM, fallback to bios file placed by the user.
+ *       - if info->path has no ROM, fallback to bios file placed by the user.
+         NOTE: info structure must be checked when is not null
  */
 bool retro_load_game(const struct retro_game_info *info)
 {
@@ -190,6 +189,7 @@ bool retro_load_game(const struct retro_game_info *info)
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -207,12 +207,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/.config/retroarch/system/PPSSPP/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/.config/retroarch/system/PPSSPP/PPSSPP*", home);
+      snprintf(emuList, sizeof(emuList), "%s/.config/retroarch/system/PPSSPP/PPSSPP*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -225,6 +235,26 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/.config/retroarch/system/PPSSPP/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
@@ -233,8 +263,10 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __WIN32__
       WIN32_FIND_DATA findFileData;
       HANDLE hFind;
+      char emuPath[256] = "C:\\RetroArch-Win64\\system\\PPSSPP";
+      char biosPath[256] = "C:\\RetroArch-Win64\\system\\PPSSPP\\bios";
       char executable[MAX_PATH] = {0};
-      char path[256] = "C:\\RetroArch-Win64\\system\\PPSSPP";
+      char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
@@ -244,7 +276,24 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      snprintf(searchPath, MAX_PATH, "%s\\PPSSPP*.exe", path);
+      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+         _mkdir(path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
+      snprintf(searchPath, MAX_PATH, "%s\\PPSSPP*.exe", emuPath);
+      hFind = FindFirstFile(searchPath, &findFileData);
+
+      if (hFind == INVALID_HANDLE_VALUE) {
+         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
+         return false;
+      }
+
+      snprintf(executable, MAX_PATH, "%s\\%s", emuPath, findFileData.cFileName);
+
+      snprintf(searchPath, MAX_PATH, "%s\\*.bin", biosPath);
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
@@ -252,13 +301,14 @@ bool retro_load_game(const struct retro_game_info *info)
          return false;
       }
       
-      snprintf(executable, MAX_PATH, "%s\\%s", path, findFileData.cFileName);
+      snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);
       FindClose(hFind);
    #elif defined __APPLE__
       
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -276,12 +326,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/Library/Application Support/RetroArch/system/PPSSPP/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/Library/Application Support/RetroArch/system/PPSSPP*", home);
+      snprintf(emuList, sizeof(emuList), "%s/Library/Application Support/RetroArch/system/PPSSPP/PPSSPP*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -294,20 +354,49 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/Library/Application Support/RetroArch/system/PPSSPP/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
       }
    #endif
-   
-   const char *args[] = {" ", "\"", info->path, "\""};
-   size_t size = sizeof(args)/sizeof(char*);
 
-   for (size_t i = 0; i < size; i++) {
-    strncat(executable, args[i], strlen(args[i]));
-   } 
-
-    printf("[LAUNCHER-INFO]: PPSSPP path: %s\n", executable);
+      if (info == NULL || info->path == NULL) {
+         if (strlen(bios) > 0) {
+            const char *args[] = {" ", bios};
+            size_t size = sizeof(args)/sizeof(char*);
+            
+            for (size_t i = 0; i < size; i++) {
+               strncat(executable, args[i], strlen(args[i]));
+            }
+         }
+      } else {
+         const char *args[] = {" ", "\"", info->path, "\""};
+         size_t size = sizeof(args)/sizeof(char*);
+         
+         for (size_t i = 0; i < size; i++) {
+            strncat(executable, args[i], strlen(args[i]));
+         }
+      }
 
    if (system(executable) == 0) {
       printf("[LAUNCHER-INFO]: Finished running PPSSPP.\n");

--- a/PPSSPP/libretro-PPSSPP-launcher.c
+++ b/PPSSPP/libretro-PPSSPP-launcher.c
@@ -271,14 +271,14 @@ bool retro_load_game(const struct retro_game_info *info)
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(emuPath);
-          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", emuPath);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(biosPath);
-          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", biosPath);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
       }

--- a/PPSSPP/libretro-PPSSPP-launcher.c
+++ b/PPSSPP/libretro-PPSSPP-launcher.c
@@ -269,14 +269,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
-       if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+       if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+      if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
@@ -297,8 +297,7 @@ bool retro_load_game(const struct retro_game_info *info)
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
-         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
-         return false;
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
       }
       
       snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);

--- a/PPSSPP/libretro-PPSSPP-launcher.c
+++ b/PPSSPP/libretro-PPSSPP-launcher.c
@@ -270,14 +270,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(emuPath);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(biosPath);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");

--- a/duckstation/libretro-duckstation-launcher.c
+++ b/duckstation/libretro-duckstation-launcher.c
@@ -164,13 +164,12 @@ static int is_elf_executable(const char *filename) {
     return (read_bytes == 4 && memcmp(magic, ELF_MAGIC, 4) == 0);
 }
 #endif
-
 /**
  * libretro callback; Called when a game is to be loaded.
  *
  *  - Linux/macOS:
  *        - resolve HOME path 
- *        - create dir for emulator files 
+ *        - create dir for emulator files and bios
  *        - apply regex search with glob, filter by file and ELF executable
  *  
  *  - Windows:
@@ -180,7 +179,8 @@ static int is_elf_executable(const char *filename) {
  *    
  * - Final Steps:
  *       - attach ROM absolute path from info->path in double quotes for system() function, avoids truncation.
- *        - if info->path has no ROM, fallback to bios file placed by the user.
+ *       - if info->path has no ROM, fallback to bios file placed by the user.
+         NOTE: info structure must be checked when is not null
  */
 bool retro_load_game(const struct retro_game_info *info)
 {
@@ -189,6 +189,7 @@ bool retro_load_game(const struct retro_game_info *info)
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -206,12 +207,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/.config/retroarch/system/duckstation/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/.config/retroarch/system/duckstation/duckstation*", home);
+      snprintf(emuList, sizeof(emuList), "%s/.config/retroarch/system/duckstation/duckstation*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -224,6 +235,26 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/.config/retroarch/system/duckstation/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
@@ -232,8 +263,10 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __WIN32__
       WIN32_FIND_DATA findFileData;
       HANDLE hFind;
+      char emuPath[256] = "C:\\RetroArch-Win64\\system\\duckstation";
+      char biosPath[256] = "C:\\RetroArch-Win64\\system\\duckstation\\bios";
       char executable[MAX_PATH] = {0};
-      char path[256] = "C:\\RetroArch-Win64\\system\\duckstation";
+      char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
@@ -243,7 +276,24 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      snprintf(searchPath, MAX_PATH, "%s\\duckstation*.exe", path);
+      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+         _mkdir(path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
+      snprintf(searchPath, MAX_PATH, "%s\\duckstation*.exe", emuPath);
+      hFind = FindFirstFile(searchPath, &findFileData);
+
+      if (hFind == INVALID_HANDLE_VALUE) {
+         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
+         return false;
+      }
+
+      snprintf(executable, MAX_PATH, "%s\\%s", emuPath, findFileData.cFileName);
+
+      snprintf(searchPath, MAX_PATH, "%s\\*.bin", biosPath);
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
@@ -251,13 +301,14 @@ bool retro_load_game(const struct retro_game_info *info)
          return false;
       }
       
-      snprintf(executable, MAX_PATH, "%s\\%s", path, findFileData.cFileName);
+      snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);
       FindClose(hFind);
    #elif defined __APPLE__
       
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -275,12 +326,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/Library/Application Support/RetroArch/system/duckstation/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/Library/Application Support/RetroArch/system/duckstation*", home);
+      snprintf(emuList, sizeof(emuList), "%s/Library/Application Support/RetroArch/system/duckstation/duckstation*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -293,20 +354,49 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/Library/Application Support/RetroArch/system/duckstation/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
       }
    #endif
-   
-   const char *args[] = {" ", "-fullscreen ", "\"", info->path, "\""};
-   size_t size = sizeof(args)/sizeof(char*);
 
-   for (size_t i = 0; i < size; i++) {
-    strncat(executable, args[i], strlen(args[i]));
-   } 
-
-    printf("[LAUNCHER-INFO]: duckstation path: %s\n", executable);
+      if (info == NULL || info->path == NULL) {
+         if (strlen(bios) > 0) {
+            const char *args[] = {" ", "-fullscreen ", bios};
+            size_t size = sizeof(args)/sizeof(char*);
+            
+            for (size_t i = 0; i < size; i++) {
+               strncat(executable, args[i], strlen(args[i]));
+            }
+         }
+      } else {
+         const char *args[] = {" ", "-fullscreen ", "\"", info->path, "\""};
+         size_t size = sizeof(args)/sizeof(char*);
+         
+         for (size_t i = 0; i < size; i++) {
+            strncat(executable, args[i], strlen(args[i]));
+         }
+      }
 
    if (system(executable) == 0) {
       printf("[LAUNCHER-INFO]: Finished running duckstation.\n");

--- a/duckstation/libretro-duckstation-launcher.c
+++ b/duckstation/libretro-duckstation-launcher.c
@@ -271,14 +271,14 @@ bool retro_load_game(const struct retro_game_info *info)
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(emuPath);
-          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", emuPath);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(biosPath);
-          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", biosPath);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
       }

--- a/duckstation/libretro-duckstation-launcher.c
+++ b/duckstation/libretro-duckstation-launcher.c
@@ -269,14 +269,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
-       if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+       if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+      if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
@@ -297,8 +297,7 @@ bool retro_load_game(const struct retro_game_info *info)
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
-         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
-         return false;
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
       }
       
       snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);

--- a/duckstation/libretro-duckstation-launcher.c
+++ b/duckstation/libretro-duckstation-launcher.c
@@ -270,14 +270,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(emuPath);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(biosPath);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");

--- a/lime3ds/libretro-lime3ds-launcher.c
+++ b/lime3ds/libretro-lime3ds-launcher.c
@@ -271,14 +271,14 @@ bool retro_load_game(const struct retro_game_info *info)
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(emuPath);
-          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", emuPath);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(biosPath);
-          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", biosPath);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
       }

--- a/lime3ds/libretro-lime3ds-launcher.c
+++ b/lime3ds/libretro-lime3ds-launcher.c
@@ -269,14 +269,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
-       if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+       if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+      if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
@@ -297,8 +297,7 @@ bool retro_load_game(const struct retro_game_info *info)
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
-         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
-         return false;
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
       }
       
       snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);

--- a/lime3ds/libretro-lime3ds-launcher.c
+++ b/lime3ds/libretro-lime3ds-launcher.c
@@ -270,14 +270,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(emuPath);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(biosPath);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");

--- a/mGBA/libretro-mGBA-launcher.c
+++ b/mGBA/libretro-mGBA-launcher.c
@@ -147,10 +147,9 @@ void retro_run(void)
 /*
    Linux/macOS: Check if file is ELF, then use it.
 */
-
 #if defined __linux__ || __APPLE__
 
- int is_elf_executable(const char *filename) {
+static int is_elf_executable(const char *filename) {
     
     unsigned char magic[4];
     int fd = open(filename, O_RDONLY);
@@ -170,7 +169,7 @@ void retro_run(void)
  *
  *  - Linux/macOS:
  *        - resolve HOME path 
- *        - create dir for emulator files 
+ *        - create dir for emulator files and bios
  *        - apply regex search with glob, filter by file and ELF executable
  *  
  *  - Windows:
@@ -180,7 +179,8 @@ void retro_run(void)
  *    
  * - Final Steps:
  *       - attach ROM absolute path from info->path in double quotes for system() function, avoids truncation.
- *        - if info->path has no ROM, fallback to bios file placed by the user.
+ *       - if info->path has no ROM, fallback to bios file placed by the user.
+         NOTE: info structure must be checked when is not null
  */
 bool retro_load_game(const struct retro_game_info *info)
 {
@@ -189,6 +189,7 @@ bool retro_load_game(const struct retro_game_info *info)
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -206,12 +207,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/.config/retroarch/system/mGBA/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/.config/retroarch/system/mGBA/mGBA*", home);
+      snprintf(emuList, sizeof(emuList), "%s/.config/retroarch/system/mGBA/mGBA*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -224,6 +235,26 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/.config/retroarch/system/mGBA/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
@@ -232,8 +263,10 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __WIN32__
       WIN32_FIND_DATA findFileData;
       HANDLE hFind;
+      char emuPath[256] = "C:\\RetroArch-Win64\\system\\mGBA";
+      char biosPath[256] = "C:\\RetroArch-Win64\\system\\mGBA\\bios";
       char executable[MAX_PATH] = {0};
-      char path[256] = "C:\\RetroArch-Win64\\system\\mGBA";
+      char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
@@ -243,7 +276,24 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      snprintf(searchPath, MAX_PATH, "%s\\mGBA*.exe", path);
+      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+         _mkdir(path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
+      snprintf(searchPath, MAX_PATH, "%s\\mGBA*.exe", emuPath);
+      hFind = FindFirstFile(searchPath, &findFileData);
+
+      if (hFind == INVALID_HANDLE_VALUE) {
+         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
+         return false;
+      }
+
+      snprintf(executable, MAX_PATH, "%s\\%s", emuPath, findFileData.cFileName);
+
+      snprintf(searchPath, MAX_PATH, "%s\\*.bin", biosPath);
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
@@ -251,13 +301,14 @@ bool retro_load_game(const struct retro_game_info *info)
          return false;
       }
       
-      snprintf(executable, MAX_PATH, "%s\\%s", path, findFileData.cFileName);
+      snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);
       FindClose(hFind);
    #elif defined __APPLE__
       
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -275,12 +326,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/Library/Application Support/RetroArch/system/mGBA/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/Library/Application Support/RetroArch/system/mGBA*", home);
+      snprintf(emuList, sizeof(emuList), "%s/Library/Application Support/RetroArch/system/mGBA/mGBA*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -293,20 +354,49 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/Library/Application Support/RetroArch/system/mGBA/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
       }
    #endif
-   
-   const char *args[] = {" ", "-f ", "\"", info->path, "\""};
-   size_t size = sizeof(args)/sizeof(char*);
 
-   for (size_t i = 0; i < size; i++) {
-    strncat(executable, args[i], strlen(args[i]));
-   } 
-
-    printf("[LAUNCHER-INFO]: mGBA path: %s\n", executable);
+      if (info == NULL || info->path == NULL) {
+         if (strlen(bios) > 0) {
+            const char *args[] = {" ", "-f ", bios};
+            size_t size = sizeof(args)/sizeof(char*);
+            
+            for (size_t i = 0; i < size; i++) {
+               strncat(executable, args[i], strlen(args[i]));
+            }
+         }
+      } else {
+         const char *args[] = {" ", "-f ", "\"", info->path, "\""};
+         size_t size = sizeof(args)/sizeof(char*);
+         
+         for (size_t i = 0; i < size; i++) {
+            strncat(executable, args[i], strlen(args[i]));
+         }
+      }
 
    if (system(executable) == 0) {
       printf("[LAUNCHER-INFO]: Finished running mGBA.\n");

--- a/mGBA/libretro-mGBA-launcher.c
+++ b/mGBA/libretro-mGBA-launcher.c
@@ -271,14 +271,14 @@ bool retro_load_game(const struct retro_game_info *info)
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(emuPath);
-          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", emuPath);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(biosPath);
-          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", biosPath);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
       }

--- a/mGBA/libretro-mGBA-launcher.c
+++ b/mGBA/libretro-mGBA-launcher.c
@@ -269,14 +269,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
-       if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+       if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+      if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
@@ -297,8 +297,7 @@ bool retro_load_game(const struct retro_game_info *info)
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
-         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
-         return false;
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
       }
       
       snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);

--- a/mGBA/libretro-mGBA-launcher.c
+++ b/mGBA/libretro-mGBA-launcher.c
@@ -270,14 +270,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(emuPath);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(biosPath);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");

--- a/melonDS/libretro-melonDS-launcher.c
+++ b/melonDS/libretro-melonDS-launcher.c
@@ -271,14 +271,14 @@ bool retro_load_game(const struct retro_game_info *info)
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(emuPath);
-          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", emuPath);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(biosPath);
-          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", biosPath);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
       }

--- a/melonDS/libretro-melonDS-launcher.c
+++ b/melonDS/libretro-melonDS-launcher.c
@@ -269,14 +269,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
-       if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+       if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+      if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
@@ -297,8 +297,7 @@ bool retro_load_game(const struct retro_game_info *info)
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
-         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
-         return false;
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
       }
       
       snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);

--- a/melonDS/libretro-melonDS-launcher.c
+++ b/melonDS/libretro-melonDS-launcher.c
@@ -270,14 +270,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(emuPath);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(biosPath);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");

--- a/melonDS/libretro-melonDS-launcher.c
+++ b/melonDS/libretro-melonDS-launcher.c
@@ -149,7 +149,7 @@ void retro_run(void)
 */
 #if defined __linux__ || __APPLE__
 
- int is_elf_executable(const char *filename) {
+static int is_elf_executable(const char *filename) {
     
     unsigned char magic[4];
     int fd = open(filename, O_RDONLY);
@@ -164,13 +164,12 @@ void retro_run(void)
     return (read_bytes == 4 && memcmp(magic, ELF_MAGIC, 4) == 0);
 }
 #endif
-
 /**
  * libretro callback; Called when a game is to be loaded.
  *
  *  - Linux/macOS:
  *        - resolve HOME path 
- *        - create dir for emulator files 
+ *        - create dir for emulator files and bios
  *        - apply regex search with glob, filter by file and ELF executable
  *  
  *  - Windows:
@@ -180,7 +179,8 @@ void retro_run(void)
  *    
  * - Final Steps:
  *       - attach ROM absolute path from info->path in double quotes for system() function, avoids truncation.
- *        - if info->path has no ROM, fallback to bios file placed by the user.
+ *       - if info->path has no ROM, fallback to bios file placed by the user.
+         NOTE: info structure must be checked when is not null
  */
 bool retro_load_game(const struct retro_game_info *info)
 {
@@ -189,6 +189,7 @@ bool retro_load_game(const struct retro_game_info *info)
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -206,12 +207,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/.config/retroarch/system/melonDS/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/.config/retroarch/system/melonDS/melonDS*", home);
+      snprintf(emuList, sizeof(emuList), "%s/.config/retroarch/system/melonDS/melonDS*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -224,6 +235,26 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/.config/retroarch/system/melonDS/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
@@ -232,8 +263,10 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __WIN32__
       WIN32_FIND_DATA findFileData;
       HANDLE hFind;
+      char emuPath[256] = "C:\\RetroArch-Win64\\system\\melonDS";
+      char biosPath[256] = "C:\\RetroArch-Win64\\system\\melonDS\\bios";
       char executable[MAX_PATH] = {0};
-      char path[256] = "C:\\RetroArch-Win64\\system\\melonDS";
+      char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
@@ -243,7 +276,24 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      snprintf(searchPath, MAX_PATH, "%s\\melonDS*.exe", path);
+      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+         _mkdir(path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
+      snprintf(searchPath, MAX_PATH, "%s\\melonDS*.exe", emuPath);
+      hFind = FindFirstFile(searchPath, &findFileData);
+
+      if (hFind == INVALID_HANDLE_VALUE) {
+         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
+         return false;
+      }
+
+      snprintf(executable, MAX_PATH, "%s\\%s", emuPath, findFileData.cFileName);
+
+      snprintf(searchPath, MAX_PATH, "%s\\*.bin", biosPath);
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
@@ -251,13 +301,14 @@ bool retro_load_game(const struct retro_game_info *info)
          return false;
       }
       
-      snprintf(executable, MAX_PATH, "%s\\%s", path, findFileData.cFileName);
+      snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);
       FindClose(hFind);
    #elif defined __APPLE__
       
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -275,12 +326,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/Library/Application Support/RetroArch/system/melonDS/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/Library/Application Support/RetroArch/system/melonDS*", home);
+      snprintf(emuList, sizeof(emuList), "%s/Library/Application Support/RetroArch/system/melonDS/melonDS*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -293,20 +354,49 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/Library/Application Support/RetroArch/system/melonDS/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
       }
    #endif
-   
-   const char *args[] = {" ", "-f ", "\"", info->path, "\""};
-   size_t size = sizeof(args)/sizeof(char*);
 
-   for (size_t i = 0; i < size; i++) {
-    strncat(executable, args[i], strlen(args[i]));
-   } 
-
-    printf("[LAUNCHER-INFO]: melonDS path: %s\n", executable);
+      if (info == NULL || info->path == NULL) {
+         if (strlen(bios) > 0) {
+            const char *args[] = {" ", "-f ", bios};
+            size_t size = sizeof(args)/sizeof(char*);
+            
+            for (size_t i = 0; i < size; i++) {
+               strncat(executable, args[i], strlen(args[i]));
+            }
+         }
+      } else {
+         const char *args[] = {" ", "-f ", "\"", info->path, "\""};
+         size_t size = sizeof(args)/sizeof(char*);
+         
+         for (size_t i = 0; i < size; i++) {
+            strncat(executable, args[i], strlen(args[i]));
+         }
+      }
 
    if (system(executable) == 0) {
       printf("[LAUNCHER-INFO]: Finished running melonDS.\n");

--- a/pcsx2/libretro-pcsx2-launcher.c
+++ b/pcsx2/libretro-pcsx2-launcher.c
@@ -271,14 +271,14 @@ bool retro_load_game(const struct retro_game_info *info)
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(emuPath);
-          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", emuPath);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(biosPath);
-          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", biosPath);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
       }

--- a/pcsx2/libretro-pcsx2-launcher.c
+++ b/pcsx2/libretro-pcsx2-launcher.c
@@ -269,14 +269,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
-       if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+       if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+      if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
@@ -297,8 +297,7 @@ bool retro_load_game(const struct retro_game_info *info)
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
-         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
-         return false;
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
       }
       
       snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);

--- a/pcsx2/libretro-pcsx2-launcher.c
+++ b/pcsx2/libretro-pcsx2-launcher.c
@@ -148,7 +148,8 @@ void retro_run(void)
    Linux/macOS: Check if file is ELF, then use it.
 */
 #if defined __linux__ || __APPLE__
- int is_elf_executable(const char *filename) {
+
+static int is_elf_executable(const char *filename) {
     
     unsigned char magic[4];
     int fd = open(filename, O_RDONLY);
@@ -168,7 +169,7 @@ void retro_run(void)
  *
  *  - Linux/macOS:
  *        - resolve HOME path 
- *        - create dir for emulator files 
+ *        - create dir for emulator files and bios
  *        - apply regex search with glob, filter by file and ELF executable
  *  
  *  - Windows:
@@ -178,7 +179,8 @@ void retro_run(void)
  *    
  * - Final Steps:
  *       - attach ROM absolute path from info->path in double quotes for system() function, avoids truncation.
- *        - if info->path has no ROM, fallback to bios file placed by the user.
+ *       - if info->path has no ROM, fallback to bios file placed by the user.
+         NOTE: info structure must be checked when is not null
  */
 bool retro_load_game(const struct retro_game_info *info)
 {
@@ -187,6 +189,7 @@ bool retro_load_game(const struct retro_game_info *info)
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -204,12 +207,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/.config/retroarch/system/pcsx2/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/.config/retroarch/system/pcsx2/pcsx2*", home);
+      snprintf(emuList, sizeof(emuList), "%s/.config/retroarch/system/pcsx2/pcsx2*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -222,6 +235,26 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/.config/retroarch/system/pcsx2/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
@@ -230,8 +263,10 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __WIN32__
       WIN32_FIND_DATA findFileData;
       HANDLE hFind;
+      char emuPath[256] = "C:\\RetroArch-Win64\\system\\pcsx2";
+      char biosPath[256] = "C:\\RetroArch-Win64\\system\\pcsx2\\bios";
       char executable[MAX_PATH] = {0};
-      char path[256] = "C:\\RetroArch-Win64\\system\\pcsx2";
+      char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
@@ -241,7 +276,24 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      snprintf(searchPath, MAX_PATH, "%s\\pcsx2*.exe", path);
+      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+         _mkdir(path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
+      snprintf(searchPath, MAX_PATH, "%s\\pcsx2*.exe", emuPath);
+      hFind = FindFirstFile(searchPath, &findFileData);
+
+      if (hFind == INVALID_HANDLE_VALUE) {
+         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
+         return false;
+      }
+
+      snprintf(executable, MAX_PATH, "%s\\%s", emuPath, findFileData.cFileName);
+
+      snprintf(searchPath, MAX_PATH, "%s\\*.bin", biosPath);
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
@@ -249,13 +301,14 @@ bool retro_load_game(const struct retro_game_info *info)
          return false;
       }
       
-      snprintf(executable, MAX_PATH, "%s\\%s", path, findFileData.cFileName);
+      snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);
       FindClose(hFind);
    #elif defined __APPLE__
       
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -273,12 +326,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/Library/Application Support/RetroArch/system/pcsx2/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/Library/Application Support/RetroArch/system/pcsx2*", home);
+      snprintf(emuList, sizeof(emuList), "%s/Library/Application Support/RetroArch/system/pcsx2/pcsx2*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -291,20 +354,49 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/Library/Application Support/RetroArch/system/pcsx2/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
       }
    #endif
-   
-   const char *args[] = {" ", "-fullscreen ", "\"", info->path, "\""};
-   size_t size = sizeof(args)/sizeof(char*);
 
-   for (size_t i = 0; i < size; i++) {
-    strncat(executable, args[i], strlen(args[i]));
-   } 
-
-    printf("[LAUNCHER-INFO]: pcsx2 path: %s\n", executable);
+      if (info == NULL || info->path == NULL) {
+         if (strlen(bios) > 0) {
+            const char *args[] = {" ", "-fullscreen ", bios};
+            size_t size = sizeof(args)/sizeof(char*);
+            
+            for (size_t i = 0; i < size; i++) {
+               strncat(executable, args[i], strlen(args[i]));
+            }
+         }
+      } else {
+         const char *args[] = {" ", "-fullscreen ", "\"", info->path, "\""};
+         size_t size = sizeof(args)/sizeof(char*);
+         
+         for (size_t i = 0; i < size; i++) {
+            strncat(executable, args[i], strlen(args[i]));
+         }
+      }
 
    if (system(executable) == 0) {
       printf("[LAUNCHER-INFO]: Finished running pcsx2.\n");

--- a/pcsx2/libretro-pcsx2-launcher.c
+++ b/pcsx2/libretro-pcsx2-launcher.c
@@ -270,14 +270,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(emuPath);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(biosPath);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");

--- a/rpcs3/libretro-rpcs3-launcher.c
+++ b/rpcs3/libretro-rpcs3-launcher.c
@@ -271,14 +271,14 @@ bool retro_load_game(const struct retro_game_info *info)
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(emuPath);
-          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", emuPath);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(biosPath);
-          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", biosPath);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
       }

--- a/rpcs3/libretro-rpcs3-launcher.c
+++ b/rpcs3/libretro-rpcs3-launcher.c
@@ -269,14 +269,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
-       if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+       if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+      if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
@@ -297,8 +297,7 @@ bool retro_load_game(const struct retro_game_info *info)
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
-         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
-         return false;
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
       }
       
       snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);

--- a/rpcs3/libretro-rpcs3-launcher.c
+++ b/rpcs3/libretro-rpcs3-launcher.c
@@ -270,14 +270,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(emuPath);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(biosPath);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");

--- a/xemu/libretro-xemu-launcher.c
+++ b/xemu/libretro-xemu-launcher.c
@@ -271,14 +271,14 @@ bool retro_load_game(const struct retro_game_info *info)
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(emuPath);
-          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", emuPath);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(biosPath);
-          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", biosPath);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
       }

--- a/xemu/libretro-xemu-launcher.c
+++ b/xemu/libretro-xemu-launcher.c
@@ -269,14 +269,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
-       if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+       if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+      if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
@@ -297,8 +297,7 @@ bool retro_load_game(const struct retro_game_info *info)
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
-         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
-         return false;
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
       }
       
       snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);

--- a/xemu/libretro-xemu-launcher.c
+++ b/xemu/libretro-xemu-launcher.c
@@ -270,14 +270,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(emuPath);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(biosPath);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");

--- a/xemu/libretro-xemu-launcher.c
+++ b/xemu/libretro-xemu-launcher.c
@@ -148,7 +148,8 @@ void retro_run(void)
    Linux/macOS: Check if file is ELF, then use it.
 */
 #if defined __linux__ || __APPLE__
- int is_elf_executable(const char *filename) {
+
+static int is_elf_executable(const char *filename) {
     
     unsigned char magic[4];
     int fd = open(filename, O_RDONLY);
@@ -168,7 +169,7 @@ void retro_run(void)
  *
  *  - Linux/macOS:
  *        - resolve HOME path 
- *        - create dir for emulator files 
+ *        - create dir for emulator files and bios
  *        - apply regex search with glob, filter by file and ELF executable
  *  
  *  - Windows:
@@ -178,7 +179,8 @@ void retro_run(void)
  *    
  * - Final Steps:
  *       - attach ROM absolute path from info->path in double quotes for system() function, avoids truncation.
- *        - if info->path has no ROM, fallback to bios file placed by the user.
+ *       - if info->path has no ROM, fallback to bios file placed by the user.
+         NOTE: info structure must be checked when is not null
  */
 bool retro_load_game(const struct retro_game_info *info)
 {
@@ -187,6 +189,7 @@ bool retro_load_game(const struct retro_game_info *info)
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -204,12 +207,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/.config/retroarch/system/xemu/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/.config/retroarch/system/xemu/xemu*", home);
+      snprintf(emuList, sizeof(emuList), "%s/.config/retroarch/system/xemu/xemu*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -222,6 +235,26 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/.config/retroarch/system/xemu/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
@@ -230,8 +263,10 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __WIN32__
       WIN32_FIND_DATA findFileData;
       HANDLE hFind;
+      char emuPath[256] = "C:\\RetroArch-Win64\\system\\xemu";
+      char biosPath[256] = "C:\\RetroArch-Win64\\system\\xemu\\bios";
       char executable[MAX_PATH] = {0};
-      char path[256] = "C:\\RetroArch-Win64\\system\\xemu";
+      char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
@@ -241,7 +276,24 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      snprintf(searchPath, MAX_PATH, "%s\\xemu*.exe", path);
+      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+         _mkdir(path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
+      snprintf(searchPath, MAX_PATH, "%s\\xemu*.exe", emuPath);
+      hFind = FindFirstFile(searchPath, &findFileData);
+
+      if (hFind == INVALID_HANDLE_VALUE) {
+         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
+         return false;
+      }
+
+      snprintf(executable, MAX_PATH, "%s\\%s", emuPath, findFileData.cFileName);
+
+      snprintf(searchPath, MAX_PATH, "%s\\*.bin", biosPath);
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
@@ -249,13 +301,14 @@ bool retro_load_game(const struct retro_game_info *info)
          return false;
       }
       
-      snprintf(executable, MAX_PATH, "%s\\%s", path, findFileData.cFileName);
+      snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);
       FindClose(hFind);
    #elif defined __APPLE__
       
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -273,12 +326,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/Library/Application Support/RetroArch/system/xemu/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/Library/Application Support/RetroArch/system/xemu*", home);
+      snprintf(emuList, sizeof(emuList), "%s/Library/Application Support/RetroArch/system/xemu/xemu*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -291,20 +354,49 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/Library/Application Support/RetroArch/system/xemu/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
       }
    #endif
-   
-   const char *args[] = {" ", "-full-screen ", "-dvd_path ", "\"", info->path, "\""};
-   size_t size = sizeof(args)/sizeof(char*);
 
-   for (size_t i = 0; i < size; i++) {
-    strncat(executable, args[i], strlen(args[i]));
-   } 
-
-    printf("[LAUNCHER-INFO]: xemu path: %s\n", executable);
+      if (info == NULL || info->path == NULL) {
+         if (strlen(bios) > 0) {
+            const char *args[] = {" ", "-full-screen ", "-dvd_path ", bios};
+            size_t size = sizeof(args)/sizeof(char*);
+            
+            for (size_t i = 0; i < size; i++) {
+               strncat(executable, args[i], strlen(args[i]));
+            }
+         }
+      } else {
+         const char *args[] = {" ", "-full-screen ", "-dvd_path ", "\"", info->path, "\""};
+         size_t size = sizeof(args)/sizeof(char*);
+         
+         for (size_t i = 0; i < size; i++) {
+            strncat(executable, args[i], strlen(args[i]));
+         }
+      }
 
    if (system(executable) == 0) {
       printf("[LAUNCHER-INFO]: Finished running xemu.\n");

--- a/xenia_canary/libretro-xenia_canary-launcher.c
+++ b/xenia_canary/libretro-xenia_canary-launcher.c
@@ -147,10 +147,9 @@ void retro_run(void)
 /*
    Linux/macOS: Check if file is ELF, then use it.
 */
-
 #if defined __linux__ || __APPLE__
 
- int is_elf_executable(const char *filename) {
+static int is_elf_executable(const char *filename) {
     
     unsigned char magic[4];
     int fd = open(filename, O_RDONLY);
@@ -170,7 +169,7 @@ void retro_run(void)
  *
  *  - Linux/macOS:
  *        - resolve HOME path 
- *        - create dir for emulator files 
+ *        - create dir for emulator files and bios
  *        - apply regex search with glob, filter by file and ELF executable
  *  
  *  - Windows:
@@ -180,6 +179,8 @@ void retro_run(void)
  *    
  * - Final Steps:
  *       - attach ROM absolute path from info->path in double quotes for system() function, avoids truncation.
+ *       - if info->path has no ROM, fallback to bios file placed by the user.
+         NOTE: info structure must be checked when is not null
  */
 bool retro_load_game(const struct retro_game_info *info)
 {
@@ -188,6 +189,7 @@ bool retro_load_game(const struct retro_game_info *info)
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -205,12 +207,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/.config/retroarch/system/xenia_canary/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/.config/retroarch/system/xenia_canary/xenia_canary*", home);
+      snprintf(emuList, sizeof(emuList), "%s/.config/retroarch/system/xenia_canary/xenia_canary*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -223,6 +235,26 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/.config/retroarch/system/xenia_canary/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
@@ -231,8 +263,10 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __WIN32__
       WIN32_FIND_DATA findFileData;
       HANDLE hFind;
+      char emuPath[256] = "C:\\RetroArch-Win64\\system\\xenia_canary";
+      char biosPath[256] = "C:\\RetroArch-Win64\\system\\xenia_canary\\bios";
       char executable[MAX_PATH] = {0};
-      char path[256] = "C:\\RetroArch-Win64\\system\\xenia_canary";
+      char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
@@ -242,7 +276,24 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      snprintf(searchPath, MAX_PATH, "%s\\xenia_canary*.exe", path);
+      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+         _mkdir(path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
+      snprintf(searchPath, MAX_PATH, "%s\\xenia_canary*.exe", emuPath);
+      hFind = FindFirstFile(searchPath, &findFileData);
+
+      if (hFind == INVALID_HANDLE_VALUE) {
+         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
+         return false;
+      }
+
+      snprintf(executable, MAX_PATH, "%s\\%s", emuPath, findFileData.cFileName);
+
+      snprintf(searchPath, MAX_PATH, "%s\\*.bin", biosPath);
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
@@ -250,13 +301,14 @@ bool retro_load_game(const struct retro_game_info *info)
          return false;
       }
       
-      snprintf(executable, MAX_PATH, "%s\\%s", path, findFileData.cFileName);
+      snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);
       FindClose(hFind);
    #elif defined __APPLE__
       
       glob_t buf;
       struct stat path_stat;
       char executable[512] = {0};
+      char bios[512] = {0};
       char path[512] = {0};
       const char *home = getenv("HOME");
       
@@ -274,12 +326,22 @@ bool retro_load_game(const struct retro_game_info *info)
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
+      // Create bios folder if it doesn't exist
+      snprintf(path, sizeof(path), "%s/Library/Application Support/RetroArch/system/xenia_canary/bios", home);
+
+      if (stat(path, &path_stat) != 0) {
+         mkdir(path, 0755);
+         printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+      } else {
+         printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
+      }
+
       // search for binary executable.
-      char tmpList[512] = {0};
+      char emuList[512] = {0};
 
-      snprintf(tmpList, sizeof(tmpList), "%s/Library/Application Support/RetroArch/system/xenia_canary*", home);
+      snprintf(emuList, sizeof(emuList), "%s/Library/Application Support/RetroArch/system/xenia_canary/xenia_canary*", home);
 
-      if (glob(tmpList, 0, NULL, &buf) == 0) {
+      if (glob(emuList, 0, NULL, &buf) == 0) {
          for (size_t i = 0; i < buf.gl_pathc; i++) {
                if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
                   if (is_elf_executable(buf.gl_pathv[i])) {
@@ -292,20 +354,49 @@ bool retro_load_game(const struct retro_game_info *info)
          globfree(&buf);
       }
 
+      // search for BIOS and initialize BIOS path
+
+      char biosList[512] = {0};
+      snprintf(biosList, sizeof(biosList), "%s/Library/Application Support/RetroArch/system/xenia_canary/bios/*.[Bb][Ii][Nn]", home);
+
+      if (glob(biosList, 0, NULL, &buf) == 0) {
+         for (size_t i = 0; i < buf.gl_pathc; i++) {
+               if (stat(buf.gl_pathv[i], &path_stat) == 0 && !S_ISDIR(path_stat.st_mode)) {
+                     snprintf(bios, sizeof(bios), "%s", buf.gl_pathv[i]);
+                     printf("[LAUNCHER-INFO]: Found BIOS: %s\n", bios);
+                     break;
+               }
+         }
+         globfree(&buf);
+      }
+
+      if (strlen(bios) == 0) {
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
+      }
+
       if (strlen(executable) == 0) {
          printf("[LAUNCHER-ERROR]: No executable found, aborting\n");
          return false;
       }
    #endif
-   
-   const char *args[] = {" ", "--fullscreen=true" "\"", info->path, "\""};
-   size_t size = sizeof(args)/sizeof(char*);
 
-   for (size_t i = 0; i < size; i++) {
-    strncat(executable, args[i], strlen(args[i]));
-   } 
-
-    printf("[LAUNCHER-INFO]: xenia_canary path: %s\n", executable);
+      if (info == NULL || info->path == NULL) {
+         if (strlen(bios) > 0) {
+            const char *args[] = {" ", "--fullscreen=true ",bios};
+            size_t size = sizeof(args)/sizeof(char*);
+            
+            for (size_t i = 0; i < size; i++) {
+               strncat(executable, args[i], strlen(args[i]));
+            }
+         }
+      } else {
+         const char *args[] = {" ", "--fullscreen=true ", "\"", info->path, "\""};
+         size_t size = sizeof(args)/sizeof(char*);
+         
+         for (size_t i = 0; i < size; i++) {
+            strncat(executable, args[i], strlen(args[i]));
+         }
+      }
 
    if (system(executable) == 0) {
       printf("[LAUNCHER-INFO]: Finished running xenia_canary.\n");

--- a/xenia_canary/libretro-xenia_canary-launcher.c
+++ b/xenia_canary/libretro-xenia_canary-launcher.c
@@ -271,14 +271,14 @@ bool retro_load_game(const struct retro_game_info *info)
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(emuPath);
-          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: emulator folder created in %s\n", emuPath);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(biosPath);
-          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
+          printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", biosPath);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");
       }

--- a/xenia_canary/libretro-xenia_canary-launcher.c
+++ b/xenia_canary/libretro-xenia_canary-launcher.c
@@ -269,14 +269,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char bios[MAX_PATH] = {0};
       char searchPath[MAX_PATH] = {0};
 
-       if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+       if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
-      if (GetFileAttributes(path) == INVALID_FILE_ATTRIBUTES) {
+      if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
          _mkdir(path);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
@@ -297,8 +297,7 @@ bool retro_load_game(const struct retro_game_info *info)
       hFind = FindFirstFile(searchPath, &findFileData);
 
       if (hFind == INVALID_HANDLE_VALUE) {
-         printf("[LAUNCHER-ERROR]: No executable found, aborting.\n");
-         return false;
+         printf("[LAUNCHER-INFO]: No BIOS given, will boot emulator UI.\n");
       }
       
       snprintf(bios, MAX_PATH, "%s\\%s", biosPath, findFileData.cFileName);

--- a/xenia_canary/libretro-xenia_canary-launcher.c
+++ b/xenia_canary/libretro-xenia_canary-launcher.c
@@ -270,14 +270,14 @@ bool retro_load_game(const struct retro_game_info *info)
       char searchPath[MAX_PATH] = {0};
 
        if (GetFileAttributes(emuPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(emuPath);
           printf("[LAUNCHER-INFO]: emulator folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: emulator folder already exist\n");
       }
 
       if (GetFileAttributes(biosPath) == INVALID_FILE_ATTRIBUTES) {
-         _mkdir(path);
+         _mkdir(biosPath);
           printf("[LAUNCHER-INFO]: BIOS folder created in %s\n", path);
       } else {
          printf("[LAUNCHER-INFO]: BIOS folder already exist\n");


### PR DESCRIPTION
- Creates `bios` folder for each emulator

- Scans for `.bin` bios, the first one detected is selected.

- Run BIOS from `run core` option.

- If the BIOS has not been detected, the core runs the emulator and only the GUI will appear.