### PR TITLE
detect emulator if downloaded for the first time

### DIFF
--- a/cores/duckstation/libretro-duckstation-launcher.c
+++ b/cores/duckstation/libretro-duckstation-launcher.c
@@ -565,6 +565,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (!setup(dirs, numPaths, executable)) {
       if (downloader(dirs, downloaderDirs, githubUrls)) {
          extractor(dirs);
+         setup(dirs, numPaths, executable);
       }
    } else {
       if (updater(dirs, downloaderDirs, githubUrls)) {
@@ -575,6 +576,7 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __linux__
    if (!setup(dirs, numPaths, executable)) {
       downloader(dirs, downloaderDirs, githubUrls);
+      setup(dirs, numPaths, executable);
    } else {
       updater(dirs, downloaderDirs, githubUrls);
    }

--- a/cores/lime3ds/libretro-lime3ds-launcher.c
+++ b/cores/lime3ds/libretro-lime3ds-launcher.c
@@ -572,6 +572,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (!setup(dirs, numPaths, executable)) {
       if (downloader(dirs, downloaderDirs, githubUrls)) {
          extractor(dirs);
+         setup(dirs, numPaths, executable);
       }
    } else {
       if (updater(dirs, downloaderDirs, githubUrls)) {

--- a/cores/mGBA/libretro-mGBA-launcher.c
+++ b/cores/mGBA/libretro-mGBA-launcher.c
@@ -587,6 +587,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (!setup(dirs, numPaths, executable)) {
       if (downloader(dirs, downloaderDirs, githubUrls)) {
          extractor(dirs);
+         setup(dirs, numPaths, executable);
       }
    } else {
       if (updater(dirs, downloaderDirs, githubUrls)) {
@@ -597,6 +598,7 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __linux__
    if (!setup(dirs, numPaths, executable)) {
       downloader(dirs, downloaderDirs, githubUrls);
+      setup(dirs, numPaths, executable);
    } else {
       updater(dirs, downloaderDirs, githubUrls);
    }

--- a/cores/melonDS/libretro-melonDS-launcher.c
+++ b/cores/melonDS/libretro-melonDS-launcher.c
@@ -575,6 +575,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (!setup(dirs, numPaths, executable)) {
       if (downloader(dirs, downloaderDirs, githubUrls)) {
          extractor(dirs);
+         setup(dirs, numPaths, executable);
       }
    } else {
       if (updater(dirs, downloaderDirs, githubUrls)) {

--- a/cores/pcsx2/libretro-pcsx2-launcher.c
+++ b/cores/pcsx2/libretro-pcsx2-launcher.c
@@ -585,6 +585,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (!setup(dirs, numPaths, executable)) {
       if (downloader(dirs, downloaderDirs, githubUrls)) {
          extractor(dirs);
+         setup(dirs, numPaths, executable);
       }
    } else {
       if (updater(dirs, downloaderDirs, githubUrls)) {
@@ -595,6 +596,7 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __linux__
    if (!setup(dirs, numPaths, executable)) {
       downloader(dirs, downloaderDirs, githubUrls);
+      setup(dirs, numPaths, executable);
    } else {
       updater(dirs, downloaderDirs, githubUrls);
    }

--- a/cores/rpcs3/libretro-rpcs3-launcher.c
+++ b/cores/rpcs3/libretro-rpcs3-launcher.c
@@ -613,6 +613,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (!setup(dirs, numPaths, executable)) {
       if (downloader(dirs, downloaderDirs, githubUrls)) {
          extractor(dirs);
+         setup(dirs, numPaths, executable);
       }
    } else {
       if (updater(dirs, downloaderDirs, githubUrls)) {
@@ -623,6 +624,7 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __linux__
    if (!setup(dirs, numPaths, executable)) {
       downloader(dirs, downloaderDirs, githubUrls);
+      setup(dirs, numPaths, executable);
    } else {
       updater(dirs, downloaderDirs, githubUrls);
    }

--- a/cores/ryujinx/libretro-ryujinx-launcher.c
+++ b/cores/ryujinx/libretro-ryujinx-launcher.c
@@ -571,6 +571,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (!setup(dirs, numPaths, executable)) {
       if (downloader(dirs, downloaderDirs, githubUrls)) {
          extractor(dirs);
+         setup(dirs, numPaths, executable);
       }
    } else {
       if (updater(dirs, downloaderDirs, githubUrls)) {
@@ -581,6 +582,7 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __linux__
    if (!setup(dirs, numPaths, executable)) {
       downloader(dirs, downloaderDirs, githubUrls);
+      setup(dirs, numPaths, executable);
    } else {
       updater(dirs, downloaderDirs, githubUrls);
    }

--- a/cores/xemu/libretro-xemu-launcher.c
+++ b/cores/xemu/libretro-xemu-launcher.c
@@ -565,6 +565,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (!setup(dirs, numPaths, executable)) {
       if (downloader(dirs, downloaderDirs, githubUrls)) {
          extractor(dirs);
+         setup(dirs, numPaths, executable);
       }
    } else {
       if (updater(dirs, downloaderDirs, githubUrls)) {
@@ -575,6 +576,7 @@ bool retro_load_game(const struct retro_game_info *info)
    #elif defined __linux__
    if (!setup(dirs, numPaths, executable)) {
       downloader(dirs, downloaderDirs, githubUrls);
+      setup(dirs, numPaths, executable);
    } else {
       updater(dirs, downloaderDirs, githubUrls);
    }

--- a/cores/xenia_canary/libretro-xenia_canary-launcher.c
+++ b/cores/xenia_canary/libretro-xenia_canary-launcher.c
@@ -596,6 +596,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (!setup(dirs, numPaths, executable)) {
       if (downloader(dirs, downloaderDirs, githubUrls)) {
          if (extractor(dirs)) {
+            setup(dirs, numPaths, executable);
             patchDownloader(dirs, githubUrls);
          }
       }


### PR DESCRIPTION
Before retroarch would download the emulator and extract it properly, but it wouldn't detect immediately the saved binary.

Instead of closing and reopening the core to detect it, detect the binary on first run.